### PR TITLE
feat: Add undefined document watcher

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -45,7 +45,10 @@ export function activate(context: ExtensionContext) {
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [{ scheme: "file", language: "epscript" }],
+    documentSelector: [
+      { scheme: "file", language: "epscript" },
+      { scheme: "untitled", language: "epscript" },
+    ],
     synchronize: {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),


### PR DESCRIPTION
This fixes eps-server Language Client send undefined files to server. See [#4](https://github.com/zuhanit/epscript-language-server/issues/4#issuecomment-1151411605).