### PR TITLE
fix: Add exist check

### DIFF
--- a/server/src/context/listener/baseListener.ts
+++ b/server/src/context/listener/baseListener.ts
@@ -116,9 +116,9 @@ export class BaseListener implements epScriptParserListener {
     const basePath = path.join(
       currentPath.dir,
       "..",
-      ...dotted.slice(0, dotted.length - 1)
+      ...dotted.slice(0, dotted.length - 1),
+      dotted[dotted.length - 1]
     );
-
     if (existsSync(basePath + ".eps")) {
       const epsPath = basePath + ".eps";
       const importURI = VSURI.file(epsPath).toString();


### PR DESCRIPTION
This PR changes algorithm of `BaseListener.enterImportStatement()`. Before the method try to get ContextPackage before check file exists. It's not good for performance and stability both. In this manner, This method changed to check file exists before collect import data.