### PR TITLE
fix: Return parent of current scope

### DIFF
--- a/server/src/context/evaluator/evaluate-this-expression.ts
+++ b/server/src/context/evaluator/evaluate-this-expression.ts
@@ -5,5 +5,8 @@ import { EvaluatorOption } from "./evaluator-options";
 export function evaluateThisExpression({
   currentScope,
 }: EvaluatorOption<ThisExpressionContext>) {
-  return currentScope as ClassSymbol;
+  if (!currentScope.parent || !ClassSymbol.isClassSymbol(currentScope.parent)) {
+    return undefined;
+  }
+  return currentScope.parent as ClassSymbol;
 }


### PR DESCRIPTION
This PR fixes this expression bug when using `this` keyword in method declaration.