### PR TITLE
Fix circular import

### DIFF
--- a/server/src/analyzer.ts
+++ b/server/src/analyzer.ts
@@ -82,11 +82,12 @@ export class Analyzer {
   public analyze(
     uri: URI,
     document: TextDocument,
-    languageManager: LanguageManager
+    languageManager: LanguageManager,
+    module = false
   ): ContextPackage {
     const contextPackage: ContextPackage = {
       document: document,
-      parsePackage: this.parser.parse(document, this, languageManager),
+      parsePackage: this.parser.parse(document, this, languageManager, module),
     };
     this.documentations.set(uri, contextPackage);
     return contextPackage;

--- a/server/src/context/listener/ModuleListener.ts
+++ b/server/src/context/listener/ModuleListener.ts
@@ -1,0 +1,20 @@
+import { epScriptParserListener } from "../../grammar/src/grammar/lib/epScriptParserListener";
+import { BaseListener } from "./BaseListener";
+
+/**
+ * 모듈 심볼 테이블 작성을 위한 리스너.
+ *
+ * 순환 참조 오류를 피하기 위해 `ModuleListener`는 ImportStatement를 건너뜁니다. 그 외의 모든 행동은 동일하게 작동합니다.
+ */
+export class ModuleListener
+  extends BaseListener
+  implements epScriptParserListener
+{
+  enterImportStatement(): void {
+    return;
+  }
+
+  exitImportStatement(): void {
+    return;
+  }
+}

--- a/server/src/context/listener/baseListener.ts
+++ b/server/src/context/listener/baseListener.ts
@@ -47,15 +47,15 @@ import { getDocumentation } from "../../util/docUtil";
  */
 export class BaseListener implements epScriptParserListener {
   public symbolTable: ContextSymbolTable;
-  private currentScope: BaseScope;
+  public currentScope: BaseScope;
 
   constructor(
-    private parser: Parser,
-    private document: TextDocument,
-    private analyzer: Analyzer,
-    private diagnostics: Diagnostic[],
-    private languageManager: LanguageManager,
-    private tokenStream: CommonTokenStream
+    public parser: Parser,
+    public document: TextDocument,
+    public analyzer: Analyzer,
+    public diagnostics: Diagnostic[],
+    public languageManager: LanguageManager,
+    public tokenStream: CommonTokenStream
   ) {
     this.symbolTable = new ContextSymbolTable(document);
     this.currentScope = this.symbolTable.globalScope;
@@ -133,7 +133,8 @@ export class BaseListener implements epScriptParserListener {
         const result = this.analyzer.analyze(
           importURI.toString(),
           TextDocument.create(importURI.toString(), "eps", 0, fileContent),
-          this.languageManager
+          this.languageManager,
+          true
         );
 
         result.parsePackage.symbolTable.globalScope

--- a/server/src/context/symbolTable/ModuleSymbol.ts
+++ b/server/src/context/symbolTable/ModuleSymbol.ts
@@ -1,9 +1,14 @@
+import { ISymbol } from "./ISymbol";
 import { SymbolWithScope } from "./SymbolWithScope";
 import { Type } from "./Type";
 import { TypedSymbol } from "./TypedSymbol";
 
 export class ModuleSymbol extends SymbolWithScope implements TypedSymbol {
   type: Type = { name: "module" };
+
+  public getAllSymbols(): ISymbol[] {
+    return [];
+  }
 
   public static isModule(arg: any): arg is ModuleSymbol {
     return arg instanceof ModuleSymbol;

--- a/server/src/document/documentSymbol.ts
+++ b/server/src/document/documentSymbol.ts
@@ -4,7 +4,7 @@ import { ContextPackage } from "../context/IContextPackage";
 import { BaseSymbol } from "../context/symbolTable/BaseSymbol";
 import { ParameterSymbol } from "../context/symbolTable/ParameterSymbol";
 
-export async function getDocumentSymbol(
+export function getDocumentSymbol(
   contextPackage: ContextPackage
 ): Promise<DocumentSymbol[]> {
   const result: DocumentSymbol[] =
@@ -21,5 +21,7 @@ export async function getDocumentSymbol(
           selectionRange: bSymbol.range,
         };
       });
-  return result;
+  return new Promise((res) => {
+    res(result);
+  });
 }


### PR DESCRIPTION
This PR fixes infinite loop while reading modules, as known as `Circular Import` issue. See #2

# Solution
- Parse modules by using `ModuleListener`. ModuleListener works like BaseListener, except pass all module reading.
- Override `getAllSymbols` of ModuleSymbol. In that manner, can't get all symbols from `ModuleSymbol`.